### PR TITLE
fix: localterra FCD for LCD

### DIFF
--- a/config.terrain.json
+++ b/config.terrain.json
@@ -23,7 +23,7 @@
   "localterra": {
     "_connection": {
       "chainID": "localterra",
-      "URL": "http://localhost:3060"
+      "URL": "http://localhost:1317"
     }
   }
 }


### PR DESCRIPTION
The FCD endpoint is not working properly on LocalTerra. Lets use the LCD API for now that way people can still use the local environment. 

Replace this with FCD when FCD works.