### PR TITLE
fix: Use https://phoenix-lcd.terra.dev instead of columbus LCD.

### DIFF
--- a/config.terrain.json
+++ b/config.terrain.json
@@ -11,7 +11,7 @@
   "mainnet": {
     "_connection": {
       "chainID": "phoenix-1",
-      "URL": "https://lcd.terra.dev"
+      "URL": "https://phoenix-lcd.terra.dev"
     }
   },
   "testnet": {


### PR DESCRIPTION
Title says it all.